### PR TITLE
make rodio support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,7 @@ categories = ["multimedia::audio"]
 [dependencies]
 mp4 = "0.12.0"
 fdk-aac = "0.4.0"
-rodio = { version = "0.16.0", default-features = false }
+rodio = { version = "0.16.0", default-features = false, optional = true }
+
+[features]
+default = [ "rodio" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,9 +167,7 @@ where
                 None => return Ok(None), // EOF
               };
               let tracks = mp4_reader.tracks();
-              let track = tracks
-                .get(&self.track_id)
-                .ok_or(Error::TrackNotFound)?;
+              let track = tracks.get(&self.track_id).ok_or(Error::TrackNotFound)?;
               let object_type = track.audio_profile().or(Err(Error::TrackReadingError))?;
               let sample_freq_index = track
                 .sample_freq_index()
@@ -244,6 +242,7 @@ where
   }
 }
 
+#[cfg(feature = "rodio")]
 impl<R> rodio::Source for Decoder<R>
 where
   R: Read + Seek,


### PR DESCRIPTION
This PR makes rodio support optional (but default).

This drops rodio's "alsa" dependency, making redlux easier to integrate when not using rodio.